### PR TITLE
Spec issues 1-5: host adapters, update discovery, remote refs, cross-platform, instructions assembly

### DIFF
--- a/docs/plans/2026-02-14-ccpkg-design.md
+++ b/docs/plans/2026-02-14-ccpkg-design.md
@@ -362,6 +362,20 @@ The ccpkg format targets multiple AI coding assistant hosts, but each host has f
 
 ---
 
+### 15. Instructions Assembly — Base + Per-Host Overlays
+
+**Decision**: The `components.instructions` field supports both a simple string form (single file) and a structured form declaring a base file with optional per-host overlay files. Overlays declare their assembly position (`append`, `prepend`, or `insert` at a named marker) via YAML frontmatter. The installer assembles the final instructions output per host at install time.
+
+**Rationale**: The original "one file, copy everywhere" model is too rigid for real-world packages. Package authors need shared context that applies to all hosts (project conventions, error handling patterns, tool usage guidelines) combined with host-specific tuning (e.g., "use Claude Code's subagent spawning" or "enable Copilot agent mode"). Rather than maintaining entirely separate instruction files per host (which defeats the shared-base purpose), the assembly model lets authors write common content once and layer host-specific additions. Three positioning strategies cover real needs: append for additive content, prepend for prerequisite notices, and marker-based insertion for content that belongs mid-document. Overlay frontmatter keeps the positioning declaration co-located with the content it governs.
+
+**Alternatives considered**:
+
+1. **Separate instruction files per host** -- Each host gets its own complete file (`claude-instructions.md`, `copilot-instructions.md`). Simple to implement but leads to content duplication. When shared content changes, authors must update N files. Rejected because it undermines the DRY principle and scales poorly with host count.
+2. **Template language with conditionals** -- Use a templating syntax (e.g., Handlebars, Jinja) with `{{#if host == "claude"}}` blocks. Powerful but introduces a template engine dependency, makes the raw files hard to read, and is overkill for what is typically "shared base + small per-host additions." Rejected for complexity.
+3. **mappings.json only (previous design)** -- Map a single canonical file to host-specific filenames without any content variation. Already proven insufficient — the filename mapping exists via `targets.*.instructions_file`, but the content is identical everywhere. Superseded by the assembly model which adds content variation on top of filename mapping.
+
+---
+
 ## Relationship to Existing Specifications
 
 ccpkg does not replace existing standards. It composes them.

--- a/spec/schemas/manifest.schema.json
+++ b/spec/schemas/manifest.schema.json
@@ -217,8 +217,31 @@
           "description": "Path to a .lsp.json template file relative to the package root."
         },
         "instructions": {
-          "type": "string",
-          "description": "Path to a canonical instructions file relative to the package root."
+          "oneOf": [
+            {
+              "type": "string",
+              "description": "Path to a single instructions file relative to the package root."
+            },
+            {
+              "type": "object",
+              "required": ["base"],
+              "additionalProperties": false,
+              "description": "Structured instructions declaration with base file and optional per-host overlays.",
+              "properties": {
+                "base": {
+                  "type": "string",
+                  "description": "Path to the base instructions file within the archive."
+                },
+                "hosts": {
+                  "type": "object",
+                  "description": "Map of host identifiers to overlay file paths within the archive.",
+                  "additionalProperties": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          ]
         }
       }
     },


### PR DESCRIPTION
## Summary

- **Canonical hook event vocabulary** — 8 portable events mapped across 5 hosts via `targets.*.hook_events`
- **Targets object extended** — `hook_events` and `mcp_env_prefix` fields with research-grounded mappings for Claude Code, Copilot, Gemini CLI, OpenCode, Codex CLI
- **Per-component host scoping** — structured component declarations with `hosts` field to scope skills/agents/commands to specific hosts
- **Version discovery + security advisories** — registry protocol endpoints for efficient update checking and vulnerability notifications
- **Remote component references** — HTTPS URLs with mandatory checksums and TTL-based caching for lightweight single-file distribution
- **Lockfile remote sources** — `remote_sources` field tracking fetched URL, checksum, and timestamp
- **Component portability matrix** — 7 component types x 5 hosts with scoping guidance
- **Manifest schema updated** — `oneOf` components, typed targets, structured instructions
- **Design decisions 11-15** — documenting rationale for all changes
- **Instructions assembly** — base + per-host overlay model with append/prepend/insert-at-marker positioning

## Commits (10)

1. `docs(spec): define canonical hook event vocabulary`
2. `docs(spec): extend targets object with hook event and MCP env mapping`
3. `docs(spec): add per-component host scoping to components object`
4. `docs(spec): add version discovery and security advisory endpoints to registry protocol`
5. `docs(spec): add remote component references section`
6. `docs(spec): add remote source and update tracking fields to lockfile`
7. `docs(spec): add component portability matrix and scoping guidance`
8. `docs(schema): update manifest schema for host scoping, remote refs, and target fields`
9. `docs(design): add design decisions 11-14 for host adapters, updates, remote refs, cross-platform`
10. `docs(spec): add instructions assembly with base + per-host overlays`

## Test plan

- [ ] Verify spec section cross-references are consistent
- [ ] Validate manifest.schema.json is well-formed JSON Schema
- [ ] Review canonical event vocabulary against host documentation
- [ ] Review instructions assembly rules for edge cases

Fixes #1, Fixes #2, Fixes #3, Fixes #4, Fixes #5